### PR TITLE
Add github-flask to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 Flask==0.11.1
+GitHub-Flask==3.1.5


### PR DESCRIPTION
I just started to play with the project, and:

```
$ pip install -r requirements.txt 
Collecting Flask==0.11.1 (from -r requirements.txt (line 1))
  Using cached Flask-0.11.1-py2.py3-none-any.whl
Collecting Werkzeug>=0.7 (from Flask==0.11.1->-r requirements.txt (line 1))
  Using cached Werkzeug-0.11.11-py2.py3-none-any.whl
Collecting Jinja2>=2.4 (from Flask==0.11.1->-r requirements.txt (line 1))
  Using cached Jinja2-2.8-py2.py3-none-any.whl
Collecting click>=2.0 (from Flask==0.11.1->-r requirements.txt (line 1))
Collecting itsdangerous>=0.21 (from Flask==0.11.1->-r requirements.txt (line 1))
Collecting MarkupSafe (from Jinja2>=2.4->Flask==0.11.1->-r requirements.txt (line 1))
Installing collected packages: Werkzeug, MarkupSafe, Jinja2, click, itsdangerous, Flask
Successfully installed Flask-0.11.1 Jinja2-2.8 MarkupSafe-0.23 Werkzeug-0.11.11 click-6.6 itsdangerous-0.24
(dateaproject) ygneo@samsagaz:~/dev/dateaproject$ python main.py 
Traceback (most recent call last):
  File "main.py", line 13, in <module>
    from flask_github import GitHub
ImportError: No module named 'flask_github'
```

So in this PR I add github_flask to requirements.
